### PR TITLE
Remove dependencies on Coveralls gem

### DIFF
--- a/lib/brcobranca/calculo_data.rb
+++ b/lib/brcobranca/calculo_data.rb
@@ -1,6 +1,9 @@
 # -*- encoding: utf-8 -*-
 #
 # @author Kivanio Barbosa
+
+require 'date'
+
 module Brcobranca
   # Métodos auxiliares de cálculos envolvendo Datas.
   module CalculoData

--- a/lib/brcobranca/validations.rb
+++ b/lib/brcobranca/validations.rb
@@ -1,8 +1,9 @@
+# coding: utf-8
 require 'brcobranca/util/errors'
 
 module Brcobranca
 
-  # Métodos auxiliares de validação para evitar ActiveSupport e ActiveModel com 
+  # Métodos auxiliares de validação para evitar ActiveSupport e ActiveModel com
   # mínimo de impacto nas definições das validações existentes
 
   module Validations
@@ -19,7 +20,7 @@ module Brcobranca
       attr_reader :inclusions
       attr_reader :eachs
 
-      def validates_presence_of(*attr_names)       
+      def validates_presence_of(*attr_names)
         @presences ||= []
         @presences = @presences << attr_names
       end
@@ -71,7 +72,7 @@ module Brcobranca
       !valid?
     end
 
-    private 
+    private
 
       def check_eachs
         eachs = {}
@@ -110,7 +111,7 @@ module Brcobranca
         all_present = true
         presences.each do |presence|
           presence.select { |p| p.is_a? Symbol}.each do |variable|
-            if self.send(variable).blank?
+            if blank?(self.send(variable))
               all_present = false
               errors.add variable, presence[-1][:message]
             end
@@ -222,5 +223,9 @@ module Brcobranca
         symbol.to_s.tr("_", " ").capitalize
       end
 
+      def blank?(obj)
+        self !~ /\S/ if obj.is_a? String
+        obj.respond_to?(:empty?) ? obj.empty? : !obj
+      end
   end
 end


### PR DESCRIPTION
During isolated tests I found a new dependency on the Coveralls gem, which should not be present on production environments.

To fix that I had to remove the usage of the `blank?` method and explicit add a require for the `Date` class where needed.